### PR TITLE
Use ChainGuard/BusyBox instead of Static as base to support GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,10 +30,12 @@ jobs:
       - run: ko publish -B ./cmd/allstar --tags ${{ github.ref_name }} --image-refs allstar.ref
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}
+          KO_DEFAULTBASEIMAGE: cgr.dev/chainguard/busybox
 
-      - run: |
-          echo "signing $(cat allstar.ref)"
-          cosign sign --yes -a git_sha="$GITHUB_SHA" "$(cat allstar.ref)"
+
+      #- run: |
+      #    echo "signing $(cat allstar.ref)"
+      #    cosign sign --yes -a git_sha="$GITHUB_SHA" "$(cat allstar.ref)"
 
       - run: gh release create ${{ github.ref_name }} --notes "ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }}"
         env:


### PR DESCRIPTION
Containers used in GitHub Actions require `tail`. This changes the base image used by ko-build to the busybox ChainGuard image.

It may make sense to build two images since the `static` base has the smaller surface area and is better for use outside of GHA.